### PR TITLE
特定ユーザの取得APIのテストを作成

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,4 +15,5 @@ sea-orm = { version = "0.12", features = [
   "sqlx-postgres",
   "runtime-tokio-native-tls",
   "macros",
+  "mock",
 ] }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,1 +1,2 @@
 pub mod test;
+pub mod user;

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -1,0 +1,8 @@
+use async_graphql::SimpleObject;
+
+#[derive(SimpleObject, Debug, Eq, PartialEq)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    pub display_name: String,
+}

--- a/backend/src/usecase.rs
+++ b/backend/src/usecase.rs
@@ -1,1 +1,2 @@
 pub mod test;
+pub mod user;

--- a/backend/src/usecase/user.rs
+++ b/backend/src/usecase/user.rs
@@ -1,0 +1,82 @@
+use crate::{context::Context, models::user::User};
+
+pub async fn get_user_by_id(_ctx: &Context, _id: &str) -> Result<User, ()> {
+    todo!();
+}
+
+#[cfg(test)]
+pub mod test {
+    use sea_orm::prelude::*;
+    use sea_orm::DatabaseConnection;
+    use sea_orm::MockDatabase;
+
+    use crate::context::Context;
+    use crate::generate::entities::user;
+    use crate::models::user::User;
+    use crate::usecase::user::get_user_by_id;
+
+    #[tokio::test]
+    async fn 指定IDのユーザが取得される() {
+        // Arrange
+        let id = "4e36eb58-49a5-43aa-935f-5a5cccb77a90";
+
+        let db: DatabaseConnection = MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+            .append_query_results([vec![user::Model {
+                id: id.to_string(),
+                user_name: "aiueo".to_string(),
+                display_name: "あいうえお".to_string(),
+                created_at: DateTime::parse_from_str("2024-08-08 00:00:00", "%Y-%m-%d %H:%M:%S")
+                    .unwrap(),
+                updated_at: DateTime::parse_from_str("2024-08-08 00:00:00", "%Y-%m-%d %H:%M:%S")
+                    .unwrap(),
+            }]])
+            .into_connection();
+
+        let ctx = Context {
+            env: "".to_string(),
+            db,
+        };
+
+        // Action
+        let result = get_user_by_id(&ctx, id).await;
+
+        // Assert
+        assert_eq!(
+            result,
+            Ok(User {
+                id: id.to_string(),
+                name: "aiueo".to_string(),
+                display_name: "あいうえお".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn 指定IDのユーザが存在しない場合失敗() {
+        // Arrange
+        let id = "4e36eb58-49a5-43aa-935f-5a5cccb77a90";
+
+        let db: DatabaseConnection = MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+            .append_query_results([vec![user::Model {
+                id: id.to_string(),
+                user_name: "aiueo".to_string(),
+                display_name: "あいうえお".to_string(),
+                created_at: DateTime::parse_from_str("2024-08-08 00:00:00", "%Y-%m-%d %H:%M:%S")
+                    .unwrap(),
+                updated_at: DateTime::parse_from_str("2024-08-08 00:00:00", "%Y-%m-%d %H:%M:%S")
+                    .unwrap(),
+            }]])
+            .into_connection();
+
+        let ctx = Context {
+            env: "".to_string(),
+            db,
+        };
+
+        // Action
+        let result = get_user_by_id(&ctx, "存在しないID").await;
+
+        // Assert
+        assert_eq!(result, Err(()));
+    }
+}


### PR DESCRIPTION
close #40 

- model/userの作成
- usecase/user -> get_user_by_idをtodoで作成
- usecase/user -> get_user_by_idのテストを作成